### PR TITLE
fix: stay logged in when user refreshed

### DIFF
--- a/src/store/auth-provider.js
+++ b/src/store/auth-provider.js
@@ -50,6 +50,19 @@ const AuthProvider = ({children}) => {
         logoutTimer = setTimeout(logoutHandler, remainingTime);
     };
 
+    useEffect(() => {
+        try{
+            const token = localStorage.getItem('token');
+            const expTime = localStorage.getItem('expTime');
+
+            if(token && expTime && new Date(expTime) > new Date){
+                setToken(token);
+            }
+        }catch (e){
+
+        }
+    }, []);
+
     useEffect(()=>{
         if (tokenData){
             logoutTimer = setTimeout(logoutHandler,tokenData.remainingTime)


### PR DESCRIPTION
When page loaded, we need to check if there is any token stored in localStorage?
if yes, then read it and set it into token state.
